### PR TITLE
Proposed partial fix for cuBLAS functional failures with SYCL 2020

### DIFF
--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -66,7 +66,7 @@ class CublasScopedContextHandler {
     bool needToRecover_;
     sycl::interop_handle &ih;
     static thread_local cublas_handle<pi_context> handle_helper;
-
+    CUstream get_stream(const sycl::queue &queue);
     sycl::context get_context(const sycl::queue &queue);
 
 public:
@@ -89,7 +89,9 @@ public:
         return reinterpret_cast<T>(cudaPtr);
     }
 
-    CUstream get_stream(const sycl::queue &queue);
+    void wait_stream(const sycl::queue &queue) {
+        cuStreamSynchronize(get_stream(queue));
+    }
 };
 
 } // namespace cublas

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -66,7 +66,7 @@ class CublasScopedContextHandler {
     bool needToRecover_;
     sycl::interop_handle &ih;
     static thread_local cublas_handle<pi_context> handle_helper;
-    CUstream get_stream(const sycl::queue &queue);
+
     sycl::context get_context(const sycl::queue &queue);
 
 public:
@@ -88,6 +88,8 @@ public:
         CUdeviceptr cudaPtr = ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc);
         return reinterpret_cast<T>(cudaPtr);
     }
+
+    CUstream get_stream(const sycl::queue &queue);
 };
 
 } // namespace cublas

--- a/src/blas/backends/cublas/cublas_task.hpp
+++ b/src/blas/backends/cublas/cublas_task.hpp
@@ -33,7 +33,7 @@ static inline void host_task_internal(H &cgh, sycl::queue queue, F f) {
     cgh.host_task([f, queue](sycl::interop_handle ih) {
         auto sc = CublasScopedContextHandler(queue, ih);
         f(sc);
-        cuStreamSynchronize(sc.get_stream(queue));
+        sc.wait_stream(queue);
     });
 }
 #endif

--- a/src/blas/backends/cublas/cublas_task.hpp
+++ b/src/blas/backends/cublas/cublas_task.hpp
@@ -33,6 +33,7 @@ static inline void host_task_internal(H &cgh, sycl::queue queue, F f) {
     cgh.host_task([f, queue](sycl::interop_handle ih) {
         auto sc = CublasScopedContextHandler(queue, ih);
         f(sc);
+        cuStreamSynchronize(sc.get_stream(queue));
     });
 }
 #endif


### PR DESCRIPTION
This fixes the functional failures (wrong results) from [Issue 175](https://github.com/oneapi-src/oneMKL/issues/175), it does not fix the segfaults.